### PR TITLE
Decode entity references in OEmbed hrefs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ function getRemoteMetadata(ctx, opts) {
       return metadata;
     }
 
-    const target = resolveUrl(ctx.url, ctx._oembed.href);
+    const target = resolveUrl(ctx.url, he_decode(ctx._oembed.href));
 
     const res = await fetch(target);
     const contentType = res.headers.get("Content-Type");

--- a/test/oembed/oembed-entities.html
+++ b/test/oembed/oembed-entities.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link rel="alternate" type="application/json+oembed" href="/oembed-service?format=json&amp;file=/json/oembed.json" />
+</head>
+<body></body>
+</html>
+
+

--- a/test/oembed/test.ts
+++ b/test/oembed/test.ts
@@ -41,6 +41,28 @@ test('width/height should be numbers', async () => {
   expect(result.oEmbed.thumbnails[0].height).toEqual(200)
 })
 
+test('should decode entities in OEmbed URL', async () => {
+  nock('http://localhost')
+    .get('/html/oembed')
+    .replyWithFile(200, __dirname + '/oembed-entities.html', {
+      'Content-Type': 'text/html'
+    })
+
+  nock('http://localhost')
+    .get('/oembed-service?format=json&file=/json/oembed.json')
+    .replyWithFile(200, __dirname + '/oembed.json', {
+      'Content-Type': 'application/json'
+    })
+
+  const result: any = await unfurl('http://localhost/html/oembed')
+
+  expect(result.oEmbed.width).toEqual(640)
+  expect(result.oEmbed.height).toEqual(640)
+
+  expect(result.oEmbed.thumbnails[0].width).toEqual(200)
+  expect(result.oEmbed.thumbnails[0].height).toEqual(200)
+})
+
 test('should prefer fetching JSON oEmbed', async () => {
   nock('http://localhost')
     .get('/html/oembed-multi')


### PR DESCRIPTION
We have had issues with a failing build in https://github.com/adobe/helix-embed/pull/84 caused by the inability to get proper OEmbeds from Youtube. Youtube uses `&amp;` entity references in the OEmbed `href`, which `unfurl` is not parsing correctly – details laid out in #45 

This PR fixes it by decoding the `href` using `he` before trying to retrieve and resolve the remote metadata.