### PR TITLE
Conditional early termination of html parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,9 @@ function getMetadata (ctx, opts: Opts) {
           }
 
           // We want to parse as little as possible so finish once we see </head>
-          if (tag === 'head') {
+          // if we have not seen a title tag within the head, we scan the entire
+          // document instead
+          if (tag === 'head' && this._title) {
             parser.reset()
           }
         }

--- a/test/basic/basic-body.html
+++ b/test/basic/basic-body.html
@@ -1,0 +1,14 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+</head>
+<body>  
+  <title>ccc</title>
+  <meta name="description" content="aaa" />
+  <meta name="keywords" content="a, b, c" />
+</body>
+</html>
+
+

--- a/test/basic/test.ts
+++ b/test/basic/test.ts
@@ -32,6 +32,25 @@ test('should detect title, description and keywords', async () => {
   expect(result).toEqual(expected)
 })
 
+test('should detect title, description and keywords even when they are in the body', async () => {
+  nock('http://localhost')
+    .get('/html/basic-body')
+    .replyWithFile(200, __dirname + '/basic-body.html', {
+      'Content-Type': 'text/html'
+    })
+
+  const result = await unfurl('http://localhost/html/basic-body')
+
+  const expected = {
+    favicon: 'http://localhost/favicon.ico',
+    description: 'aaa',
+    keywords: ['a', 'b', 'c'],
+    title: 'ccc'
+  }
+
+  expect(result).toEqual(expected)
+})
+
 test('should detect title, description and keywords', async () => {
   nock('http://localhost')
     .get('/html/basic')


### PR DESCRIPTION
This is a fix for #67 

It will only stop parsing after seeing the closing `head` tag if a `title` has been found, otherwise it assumes the HTML has been written with less care and as a consequence, the entire document will be scanned for metadata clues.