### PR TITLE
Add favicon property in the metadata type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export type Metadata = {
   title: string
   description: string
   keywords: string[]
+  favicon?: string
   oEmbed?: {
     type: 'photo' | 'video' | 'link' | 'rich'
     version?: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export type Metadata = {
   title: string
   description: string
   keywords: string[]
-  favicon?: string
+  favicon: string
   oEmbed?: {
     type: 'photo' | 'video' | 'link' | 'rich'
     version?: string


### PR DESCRIPTION
The `favicon` URL seems to be missing from the `Metadata` type although [it can be pushed in the metadata](https://github.com/jacktuck/unfurl/blob/47f12ba5592d6cb7500bc8c09eb3da5bf61f5938/src/index.ts#L208-L209) and it is [tested](https://github.com/glebedel/jacktuck/blob/47f12ba5592d6cb7500bc8c09eb3da5bf61f5938/test/encoding/test.ts#L17-L18)

Edit: Resolves #63