### PR TITLE
Handle atomic tags in meta tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -250,9 +250,9 @@ function getMetadata (ctx, opts: Opts) {
           let pair
 
           if (tagname === 'meta') {
-            if (attribs.name === 'description') {
+            if (attribs.name === 'description' && attribs.content) {
               pair = ['description', attribs.content]
-            } else if (attribs.name === 'keywords') {
+            } else if (attribs.name === 'keywords' && attribs.content) {
               let keywords = attribs.content
                 .replace(/^[,\s]{1,}|[,\s]{1,}$/g, '') // gets rid of trailing space or sommas
                 .split(/,{1,}\s{0,}/) // splits on 1+ commas followed by 0+ spaces


### PR DESCRIPTION
Hi Jack, thank you for sharing your wonderful code.

I noticed that some sites have empty (i.e. _atomic_) meta tags, such as `<meta name="description"/>` and `<meta name="keywords"/>`.
We simply need to check if `attrib.content` exists before using it.

I fixed two lines of code (253 and 255).

Ciao,
Paolo