### PR TITLE
feat: Add support for meta tag author

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -270,6 +270,8 @@ function getMetadata (ctx, opts: Opts) {
           if (tagname === 'meta') {
             if (attribs.name === 'description' && attribs.content) {
               pair = ['description', attribs.content]
+            } else if (attribs.name === 'author' && attribs.content) {
+              pair = ['author', attribs.content]
             } else if (attribs.name === 'keywords' && attribs.content) {
               let keywords = attribs.content
                 .replace(/^[,\s]{1,}|[,\s]{1,}$/g, '') // gets rid of trailing space or sommas

--- a/test/basic/basic.html
+++ b/test/basic/basic.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>ccc</title>
+  <meta name="author" content="abc" />
   <meta name="description" content="aaa" />
   <meta name="keywords" content="a, b, c" />
 </head>

--- a/test/basic/test.ts
+++ b/test/basic/test.ts
@@ -52,6 +52,26 @@ test('should detect title, description and keywords even when they are in the bo
   expect(result).toEqual(expected)
 })
 
+test('should detect title, description and keywords', async () => {
+  nock('http://localhost')
+    .get('/html/basic')
+    .replyWithFile(200, __dirname + '/basic.html', {
+      'Content-Type': 'text/html'
+    })
+
+  const result = await unfurl('http://localhost/html/basic')
+
+  const expected = {
+    favicon: 'http://localhost/favicon.ico',
+    author: 'abc',
+    description: 'aaa',
+    keywords: ['a', 'b', 'c'],
+    title: 'ccc'
+  }
+
+  expect(result).toEqual(expected)
+})
+
 test('should detect last dupe of title, description and keywords', async () => {
   nock('http://localhost')
     .get('/html/basic-duplicates')

--- a/test/basic/test.ts
+++ b/test/basic/test.ts
@@ -24,6 +24,7 @@ test('should detect title, description and keywords', async () => {
 
   const expected = {
     favicon: 'http://localhost/favicon.ico',
+    author: 'abc',
     description: 'aaa',
     keywords: ['a', 'b', 'c'],
     title: 'ccc'
@@ -40,25 +41,6 @@ test('should detect title, description and keywords even when they are in the bo
     })
 
   const result = await unfurl('http://localhost/html/basic-body')
-
-  const expected = {
-    favicon: 'http://localhost/favicon.ico',
-    description: 'aaa',
-    keywords: ['a', 'b', 'c'],
-    title: 'ccc'
-  }
-
-  expect(result).toEqual(expected)
-})
-
-test('should detect title, description and keywords', async () => {
-  nock('http://localhost')
-    .get('/html/basic')
-    .replyWithFile(200, __dirname + '/basic.html', {
-      'Content-Type': 'text/html'
-    })
-
-  const result = await unfurl('http://localhost/html/basic')
 
   const expected = {
     favicon: 'http://localhost/favicon.ico',


### PR DESCRIPTION
Added the ability to interpret standard metadata authoring as defined by the HTML specification.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name

Note: Deleted because there was a test case with the same content.