### PR TITLE
Use global URL object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unfurl.js",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "version": "5.1.0",
   "description": "Scraper for oEmbed, Twitter Cards and Open Graph metadata - fast and Promise-based",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ if (process.env.NODE_ENV !== 'test') {
   require('source-map-support').install()
 }
 
-import { URL } from 'url'
 import { Parser } from 'htmlparser2'
 import fetch from 'node-fetch'
 import UnexpectedError from './unexpectedError'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "sourceMap": true,
-    "lib": ["es2017"],
+    "lib": ["es2017", "dom"],
     "module": "commonjs",
     "target": "es2017",
     "declaration": true


### PR DESCRIPTION
The global `URL` has been added in Node.js v10.

This would be technically a breaking change, but I doubt people are still using Node.js older than v10. Version 12 is the oldest LTS at this moment.