### PR TITLE
fix(): Added support for CDATA escaped html fields on xml oembed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,18 @@ function getRemoteMetadata (ctx, opts) {
           },
           ontext: function (text) {
             if (!this._text) this._text = ''
-            this._text += text
+
+            if (this._tagname === 'html' && text) {
+              if (!content.html) {
+                content.html = ''
+              }
+              content.html += text.trim()
+                .replace(/&gt;/ig, '>')
+                .replace(/&lt;/ig, '<')
+                .replace(/(?:^<!\[CDATA\[)|(?:\]\]>$)/ig, '')
+            } else {
+              this._text += text
+            }
           },
           onclosetag: function (tagname) {
             if (tagname === 'oembed') {

--- a/test/oembed/oembed-cdata.xml
+++ b/test/oembed/oembed-cdata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oembed>
+  <version type="float">1.0</version>
+  <type>rich</type>
+  <provider-name>SoundCloud</provider-name>
+  <provider-url>https://soundcloud.com</provider-url>
+  <height type="integer">400</height>
+  <width>100%</width>
+  <title>Bugle 179 - Playas gon play by The Bugle</title>
+  <description>This week - oh PIPA, Republican't candidates and Craptain Italia. Remember to #savethebugle at http://www.thebuglepodcast.com</description>
+  <thumbnail-url>https://i1.sndcdn.com/artworks-000017079411-pgm0ii-t500x500.jpg</thumbnail-url>
+  <html>&lt;![CDATA[&lt;iframe width="100%" height="400" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?visual=true&amp;url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F34019569&amp;show_artwork=true"&gt;&lt;/iframe&gt;]]&gt;</html>
+  <author-name>The Bugle</author-name>
+  <author-url>https://soundcloud.com/the-bugle</author-url>
+</oembed>

--- a/test/oembed/oembed-xml-cdata.html
+++ b/test/oembed/oembed-xml-cdata.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="alternate" type="text/xml+oembed" href="/xml/oembed-cdata.xml" />
+  </head>
+  <body></body>
+</html>

--- a/test/oembed/test.ts
+++ b/test/oembed/test.ts
@@ -196,3 +196,32 @@ test('should build oEmbed from XML', async () => {
 
   expect(result.oEmbed).toEqual(expected)
 })
+
+test('should build oEmbed from XML with CDATA', async () => {
+  nock('http://localhost')
+    .get('/html/oembed-xml-cdata')
+    .replyWithFile(200, __dirname + '/oembed-xml-cdata.html', {
+      'Content-Type': 'text/html'
+    })
+
+  nock('http://localhost')
+    .get('/xml/oembed-cdata.xml')
+    .replyWithFile(200, __dirname + '/oembed-cdata.xml', {
+      'Content-Type': 'text/xml'
+    })
+
+  const result: any = await unfurl('http://localhost/html/oembed-xml-cdata')
+
+  const expected = {
+    height: 400,
+    title: "Bugle 179 - Playas gon play by The Bugle",
+    type: "rich",
+    version: "1.0",
+    width: 100,
+    html: '<iframe width="100%" height="400" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F34019569&show_artwork=true"></iframe>',
+  }
+
+  expect(result.oEmbed).toEqual(expected)
+})
+
+


### PR DESCRIPTION
While doing some tests with `unfurl` I stumble upon Soundcloud XML implementation which was only partially working.

Looking at [their XML](https://soundcloud.com/oembed?url=https%3A%2F%2Fsoundcloud.com%2Fthe-bugle%2Fbugle-179-playas-gon-play&format=xml) it seems that they are escaping their html node with `CDATA` which is not unreasonable to be fair:

```xml
<oembed>
  <version type="float">1.0</version>
  <type>rich</type>
  <provider-name>SoundCloud</provider-name>
  <provider-url>https://soundcloud.com</provider-url>
  <height type="integer">400</height>
  <width>100%</width>
  <title>Bugle 179 - Playas gon play by The Bugle</title>
  <description>This week - oh PIPA, Republican't candidates and Craptain Italia. Remember to #savethebugle at http://www.thebuglepodcast.com</description>
  <thumbnail-url>https://i1.sndcdn.com/artworks-000017079411-pgm0ii-t500x500.jpg</thumbnail-url>
  <html><![CDATA[<iframe width="100%" height="400" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F34019569&show_artwork=true"></iframe>]]></html>
  <author-name>The Bugle</author-name>
  <author-url>https://soundcloud.com/the-bugle</author-url>
</oembed>
```

Now unfurl use of htmlparser assumes that any content on the html block will show up as a new tag but that is not the case here, it will show up as text. 

So what I have done is to naively check for the tagname while we read text and assume that if we have any text on an html tag it will be for something like this. In that scenario I have, again verynaively, escaped that `&lt;` and `&gt;` adn the `CDATA` and push that string into the `content.html`.

I have added a new test to cover this, including the example from soudlocud, and everything seems fine. There is certainly room for improvement, that sanitisation of the `CDATA` is not the best but it does the job for the type of content that we will usually get in that field.