### PR TITLE
feat: adding theme-color meta data

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ type Metadata = {
   keywords?: string[]
   favicon?: string
   author?: string
+  theme_color?: string
   oEmbed?: {
     type: 'photo' | 'video' | 'link' | 'rich'
     version?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,6 +322,8 @@ function getMetadata(url: string, opts: Opts) {
               pair = ["description", attribs.content];
             } else if (attribs.name === "author" && attribs.content) {
               pair = ["author", attribs.content];
+            } else if (attribs.name === "theme-color" && attribs.content) {
+              pair = ["theme_color", attribs.content];
             } else if (attribs.name === "keywords" && attribs.content) {
               const keywords = attribs.content
                 .replace(/^[,\s]{1,}|[,\s]{1,}$/g, "") // gets rid of trailing space or sommas

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type Metadata = {
   keywords?: string[];
   favicon?: string;
   author?: string;
+  theme_color?: string;
   oEmbed?: {
     type: "photo" | "video" | "link" | "rich";
     width?: number;

--- a/test/basic/basic.html
+++ b/test/basic/basic.html
@@ -7,6 +7,7 @@
   <meta name="author" content="abc" />
   <meta name="description" content="aaa" />
   <meta name="keywords" content="a, b, c" />
+  <meta name="theme-color" content="#ff00ff" />
 </head>
 <body></body>
 </html>

--- a/test/basic/test.ts
+++ b/test/basic/test.ts
@@ -53,27 +53,6 @@ test("should detect title, description and keywords even when they are in the bo
   expect(result).toEqual(expected);
 });
 
-test("should detect title, description and keywords", async () => {
-  nock("http://localhost")
-    .get("/html/basic")
-    .replyWithFile(200, __dirname + "/basic.html", {
-      "Content-Type": "text/html",
-    });
-
-  const result = await unfurl("http://localhost/html/basic");
-
-  const expected = {
-    favicon: "http://localhost/favicon.ico",
-    author: "abc",
-    description: "aaa",
-    keywords: ["a", "b", "c"],
-    title: "ccc",
-    theme_color: "#ff00ff",
-  };
-
-  expect(result).toEqual(expected);
-});
-
 test("should detect last dupe of title, description and keywords", async () => {
   nock("http://localhost")
     .get("/html/basic-duplicates")

--- a/test/basic/test.ts
+++ b/test/basic/test.ts
@@ -28,6 +28,7 @@ test("should detect title, description and keywords", async () => {
     description: "aaa",
     keywords: ["a", "b", "c"],
     title: "ccc",
+    theme_color: "#ff00ff",
   };
 
   expect(result).toEqual(expected);
@@ -67,6 +68,7 @@ test("should detect title, description and keywords", async () => {
     description: "aaa",
     keywords: ["a", "b", "c"],
     title: "ccc",
+    theme_color: "#ff00ff",
   };
 
   expect(result).toEqual(expected);


### PR DESCRIPTION
adds support for the [theme-color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color) meta tag making it available as `theme_color` at the top level of the response object.

Side note: I noticed that the test in `/test/basic/tests.ts` labeled `should detect title, description and keywords` appears to be there twice. I wasn't sure if there was any reason for this though. Should the duplicate be removed? And should the label of the remaining de-duped test read more like `should detect favicon, author, description, keywords, title, and theme_color` (just to be more accurate)?