### PR TITLE
Add export type Metadata and UnexpectedError

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -469,4 +469,5 @@ function parse(url: string) {
   };
 }
 
-export { unfurl, Metadata, UnexpectedError };
+export { unfurl };
+export type { Metadata, UnexpectedError };

--- a/src/index.ts
+++ b/src/index.ts
@@ -469,4 +469,4 @@ function parse(url: string) {
   };
 }
 
-export { unfurl };
+export { unfurl, Metadata, UnexpectedError };


### PR DESCRIPTION
I thought it would be more convenient to have these types exported for type annotation of variables and error handling.

Thanks for the great library!