### PR TITLE
feat: Improve type inference for oEmbed type in TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,21 +58,7 @@ type Metadata = {
   author?: string
   theme_color?: string
   canonical_url?: string
-  oEmbed?: {
-    type: 'photo' | 'video' | 'link' | 'rich'
-    version?: string
-    title?: string
-    author_name?: string
-    author_url?: string
-    provider_name?: string
-    provider_url?: string
-    cache_age?: number
-    thumbnails?: [{
-      url?: string
-      width?: number
-      height?: number
-    }]
-  }
+  oEmbed?: OEmbedPhoto | OEmbedVideo | OEmbedLink | OEmbedRich
   twitter_card: {
     card: string
     site?: string
@@ -146,6 +132,49 @@ type Metadata = {
       tags?: string[]
     }
   }
+}
+
+type OEmbedBase = {
+  type: "photo" | "video" | "link" | "rich"
+  version: string
+  title?: string
+  author_name?: string
+  author_url?: string
+  provider_name?: string
+  provider_url?: string
+  cache_age?: number
+  thumbnails?: [
+    {
+      url?: string
+      width?: number
+      height?: number
+    }
+  ]
+}
+
+type OEmbedPhoto = OEmbedBase & {
+  type: "photo"
+  url: string
+  width: number
+  height: number
+}
+
+type OEmbedVideo = OEmbedBase & {
+  type: "video"
+  html: string
+  width: number
+  height: number
+}
+
+type OEmbedLink = OEmbedBase & {
+  type: "link"
+}
+
+type OEmbedRich = OEmbedBase & {
+  type: "rich"
+  html: string
+  width: number
+  height: number
 }
 ```
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,25 +24,7 @@ export type Metadata = {
   author?: string;
   theme_color?: string;
   canonical_url?: string;
-  oEmbed?: {
-    type: "photo" | "video" | "link" | "rich";
-    width?: number;
-    height?: number;
-    version?: string;
-    title?: string;
-    author_name?: string;
-    author_url?: string;
-    provider_name?: string;
-    provider_url?: string;
-    cache_age?: number;
-    thumbnails?: [
-      {
-        url?: string;
-        width?: number;
-        height?: number;
-      }
-    ];
-  };
+  oEmbed?: OEmbedPhoto | OEmbedVideo | OEmbedLink | OEmbedRich;
   twitter_card: {
     card: string;
     site?: string;
@@ -117,3 +99,46 @@ export type Metadata = {
     };
   };
 };
+
+type OEmbedBase = {
+  type: "photo" | "video" | "link" | "rich";
+  version: string;
+  title?: string;
+  author_name?: string;
+  author_url?: string;
+  provider_name?: string;
+  provider_url?: string;
+  cache_age?: number;
+  thumbnails?: [
+    {
+      url?: string;
+      width?: number;
+      height?: number;
+    }
+  ];
+}
+
+type OEmbedPhoto = OEmbedBase & {
+  type: "photo";
+  url: string;
+  width: number;
+  height: number;
+}
+
+type OEmbedVideo = OEmbedBase & {
+  type: "video";
+  html: string;
+  width: number;
+  height: number;
+}
+
+type OEmbedLink = OEmbedBase & {
+  type: "link";
+}
+
+type OEmbedRich = OEmbedBase & {
+  type: "rich";
+  html: string;
+  width: number;
+  height: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,29 +116,29 @@ type OEmbedBase = {
       height?: number;
     }
   ];
-}
+};
 
 type OEmbedPhoto = OEmbedBase & {
   type: "photo";
   url: string;
   width: number;
   height: number;
-}
+};
 
 type OEmbedVideo = OEmbedBase & {
   type: "video";
   html: string;
   width: number;
   height: number;
-}
+};
 
 type OEmbedLink = OEmbedBase & {
   type: "link";
-}
+};
 
 type OEmbedRich = OEmbedBase & {
   type: "rich";
   html: string;
   width: number;
   height: number;
-}
+};

--- a/test/oembed/test.ts
+++ b/test/oembed/test.ts
@@ -32,11 +32,15 @@ test("width/height should be numbers", async () => {
 
   const result = await unfurl("http://localhost/html/oembed");
 
-  expect(result.oEmbed.width).toEqual(640);
-  expect(result.oEmbed.height).toEqual(640);
+  expect(result.oEmbed?.type).toEqual("video");
+  const oEmbed =
+    result.oEmbed?.type === "video" ? result.oEmbed : (result.oEmbed as never);
 
-  expect(result.oEmbed.thumbnails[0].width).toEqual(200);
-  expect(result.oEmbed.thumbnails[0].height).toEqual(200);
+  expect(oEmbed.width).toEqual(640);
+  expect(oEmbed.height).toEqual(640);
+
+  expect(oEmbed.thumbnails?.[0].width).toEqual(200);
+  expect(oEmbed.thumbnails?.[0].height).toEqual(200);
 });
 
 test("should decode entities in OEmbed URL", async () => {
@@ -54,11 +58,15 @@ test("should decode entities in OEmbed URL", async () => {
 
   const result = await unfurl("http://localhost/html/oembed");
 
-  expect(result.oEmbed.width).toEqual(640);
-  expect(result.oEmbed.height).toEqual(640);
+  expect(result.oEmbed?.type).toEqual("video");
+  const oEmbed =
+    result.oEmbed?.type === "video" ? result.oEmbed : (result.oEmbed as never);
 
-  expect(result.oEmbed.thumbnails[0].width).toEqual(200);
-  expect(result.oEmbed.thumbnails[0].height).toEqual(200);
+  expect(oEmbed.width).toEqual(640);
+  expect(oEmbed.height).toEqual(640);
+
+  expect(oEmbed.thumbnails?.[0].width).toEqual(200);
+  expect(oEmbed.thumbnails?.[0].height).toEqual(200);
 });
 
 test("should prefer fetching JSON oEmbed", async () => {
@@ -118,7 +126,7 @@ test("should upgrade to HTTPS if needed", async () => {
 
   const result = await unfurl("http://localhost/html/oembed-http");
 
-  expect(result.oEmbed.version).toEqual("1.0");
+  expect(result.oEmbed?.version).toEqual("1.0");
 });
 
 test("should build oEmbed from JSON", async () => {


### PR DESCRIPTION
## Motivation

There are four types of oEmbed: Photo, Video, Rich, and Link. And each of these has different fields that exist depending on the type. Therefore, it seems that the TypeScript type of oEmbed should be appropriately inferred according to the oEmbed type.

```ts
// Before
const metadata = await unfurl("https://example.com")
if (!metadata.oEmbed) return

switch (metadata.oEmbed.type) {
  case "photo":
    // url, width and height should exist and not be undefined because these are required fields for photo type
    const url: string = metadata.oEmbed.url       // ❌ Property 'url' does not exist on type '{ type: "photo" | "video" | "link" | "rich"; width?: number | undefined; height?: number | undefined; version?: string | undefined; title?: string | undefined; author_name?: string | undefined; ... 4 more ...; thumbnails?: [...] | undefined; }'
    const width: number = metadata.oEmbed.width   // ❌ Type 'number | undefined' is not assignable to type 'number'
    const height: number = metadata.oEmbed.height // ❌ Type 'number | undefined' is not assignable to type 'number'
    break

  case "video":
  case "rich":
    // html, width and height should exist and not be undefined because these are required fields for video and rich type
    const html: string = metadata.oEmbed.html     // ❌ Property 'html' does not exist on type '{ type: "photo" | "video" | "link" | "rich"; width?: number | undefined; height?: number | undefined; version?: string | undefined; title?: string | undefined; author_name?: string | undefined; ... 4 more ...; thumbnails?: [...] | undefined; }'
    const width: number = metadata.oEmbed.width   // ❌ Type 'number | undefined' is not assignable to type 'number'
    const height: number = metadata.oEmbed.height // ❌ Type 'number | undefined' is not assignable to type 'number'
    break
}
```

```ts
// After
const metadata = await unfurl("https://example.com")
if (!metadata.oEmbed) return

switch (metadata.oEmbed.type) {
  case "photo":
    const url: string = metadata.oEmbed.url       // ✅
    const width: number = metadata.oEmbed.width   // ✅
    const height: number = metadata.oEmbed.height // ✅
    break

  case "video":
  case "rich":
    const html: string = metadata.oEmbed.html     // ✅
    const width: number = metadata.oEmbed.width   // ✅
    const height: number = metadata.oEmbed.height // ✅
    break
}
```

oEmbed's TypeScript types were implemented based on the following specification.

> #### 2.3.4. Response parameters
> Responses can specify a resource type, such as photo or video. Each type has specific parameters associated with it. The following response parameters are valid for all response types:
> 
> - type (required)
>   The resource type. Valid values, along with value-specific parameters, are described below.
> - version (required)
>   The oEmbed version number. This must be 1.0.
> - title (optional)
>   A text title, describing the resource.
> - author_name (optional)
>   The name of the author/owner of the resource.
> - author_url (optional)
>   A URL for the author/owner of the resource.
> - provider_name (optional)
>   The name of the resource provider.
> - provider_url (optional)
>   The url of the resource provider.
> - cache_age (optional)
>   The suggested cache lifetime for this resource, in seconds. Consumers may choose to use this value or not.
> - thumbnail_url (optional)
>   A URL to a thumbnail image representing the resource. The thumbnail must respect any maxwidth and maxheight parameters. If this parameter is present, thumbnail_width and thumbnail_height must also be present.
> - thumbnail_width (optional)
> The width of the optional thumbnail. If this parameter is present, thumbnail_url and thumbnail_height must also be present.
> - thumbnail_height (optional)
>   The height of the optional thumbnail. If this parameter is present, thumbnail_url and thumbnail_width must also be present.
> 
> Providers may optionally include any parameters not specified in this document (so long as they use the same key-value format) and consumers may choose to ignore these. Consumers must ignore parameters they do not understand.
> 
> #### 2.3.4.1. The photo type
> This type is used for representing static photos. The following parameters are defined:
> 
> - url (required)
>   The source URL of the image. Consumers should be able to insert this URL into an <img> element. Only HTTP and HTTPS URLs are valid.
> - width (required)
>   The width in pixels of the image specified in the url parameter.
> - height (required)
>   The height in pixels of the image specified in the url parameter.
> 
> Responses of this type must obey the maxwidth and maxheight request parameters.
> 
> #### 2.3.4.2. The video type
> This type is used for representing playable videos. The following parameters are defined:
> 
> - html (required)
>   The HTML required to embed a video player. The HTML should have no padding or margins. Consumers may wish to load the HTML in an off-domain iframe to avoid XSS vulnerabilities.
> - width (required)
>   The width in pixels required to display the HTML.
> - height (required)
>   The height in pixels required to display the HTML.
> 
> Responses of this type must obey the maxwidth and maxheight request parameters. If a provider wishes the consumer to just provide a thumbnail, rather than an embeddable player, they should instead return a photo response type.
> 
> #### 2.3.4.3. The link type
> Responses of this type allow a provider to return any generic embed data (such as title and author_name), without providing either the url or html parameters. The consumer may then link to the resource, using the URL specified in the original request.
> 
> #### 2.3.4.4. The rich type
> This type is used for rich HTML content that does not fall under one of the other categories. The following parameters are defined:
> 
> - html (required)
>   The HTML required to display the resource. The HTML should have no padding or margins. Consumers may wish to load the HTML in an off-domain iframe to avoid XSS vulnerabilities. The markup should be valid XHTML 1.0 Basic.
> - width (required)
>   The width in pixels required to display the HTML.
> - height (required)
>   The height in pixels required to display the HTML.
> 
> Responses of this type must obey the maxwidth and maxheight request parameters.
> 
> https://oembed.com/#section2